### PR TITLE
feat: Change Account & add Apple Login 

### DIFF
--- a/Mongsil/Mongsil.xcodeproj/project.pbxproj
+++ b/Mongsil/Mongsil.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		125F84B2280D124F00279C42 /* AlertDoubleButtonCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125F84B1280D124F00279C42 /* AlertDoubleButtonCore.swift */; };
 		125F84B7280D14AB00279C42 /* AlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125F84B6280D14AB00279C42 /* AlertButton.swift */; };
 		125F84B9280D151800279C42 /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125F84B8280D151800279C42 /* LoadingIndicator.swift */; };
+		126E471028220181008D1554 /* AppleLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126E470F28220181008D1554 /* AppleLoginService.swift */; };
 		126EF42D27F2AC2400102FA9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 126EF42C27F2AC2400102FA9 /* Assets.xcassets */; };
 		126EF43027F2AC2400102FA9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 126EF42F27F2AC2400102FA9 /* Preview Assets.xcassets */; };
 		127EBD78280A65960011C556 /* UINavigationController+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127EBD77280A65960011C556 /* UINavigationController+extensions.swift */; };
@@ -67,6 +68,7 @@
 		12A2245627F7E76F00617C10 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12A2245527F7E76F00617C10 /* HomeView.swift */; };
 		12A2245827F7E77700617C10 /* HomeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12A2245727F7E77700617C10 /* HomeCore.swift */; };
 		12D775DB28024B8C00CD0CFD /* Rswift in Frameworks */ = {isa = PBXBuildFile; productRef = 12D775DA28024B8C00CD0CFD /* Rswift */; };
+		12D7D3CD281E91EA00B83DDE /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D7D3CC281E91EA00B83DDE /* UserService.swift */; };
 		12EF96B028195DF2002CEFFA /* MSTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12EF96AF28195DF2002CEFFA /* MSTabView.swift */; };
 		12F1DBD827F4119A0063A84D /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 12F1DBD727F4119A0063A84D /* ComposableArchitecture */; };
 		12F1DBDB27F411A80063A84D /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 12F1DBDA27F411A80063A84D /* Alamofire */; };
@@ -128,6 +130,7 @@
 		125F84B1280D124F00279C42 /* AlertDoubleButtonCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDoubleButtonCore.swift; sourceTree = "<group>"; };
 		125F84B6280D14AB00279C42 /* AlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertButton.swift; sourceTree = "<group>"; };
 		125F84B8280D151800279C42 /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
+		126E470F28220181008D1554 /* AppleLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginService.swift; sourceTree = "<group>"; };
 		126EF42527F2AC2400102FA9 /* Mongsil.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mongsil.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		126EF42C27F2AC2400102FA9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		126EF42F27F2AC2400102FA9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -147,6 +150,7 @@
 		12A2245327F7E5D300617C10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		12A2245527F7E76F00617C10 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		12A2245727F7E77700617C10 /* HomeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCore.swift; sourceTree = "<group>"; };
+		12D7D3CC281E91EA00B83DDE /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
 		12EF96AF28195DF2002CEFFA /* MSTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSTabView.swift; sourceTree = "<group>"; };
 		773AE2A5280723DC006861FC /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		773AE2A7280723E6006861FC /* MainTabCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabCore.swift; sourceTree = "<group>"; };
@@ -365,7 +369,9 @@
 			isa = PBXGroup;
 			children = (
 				F03FF6CA28099B7900E83570 /* KakaoLoginService.swift */,
+				126E470F28220181008D1554 /* AppleLoginService.swift */,
 				12273EEF27F91076007624C1 /* AppTrackingService.swift */,
+				12D7D3CC281E91EA00B83DDE /* UserService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -624,9 +630,10 @@
 			};
 			buildConfigurationList = 126EF42027F2AC2400102FA9 /* Build configuration list for PBXProject "Mongsil" */;
 			compatibilityVersion = "Xcode 13.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				ko,
 				en,
 				Base,
 			);
@@ -717,6 +724,7 @@
 				1291296727F812FE0017E087 /* Reducer+extensions.swift in Sources */,
 				12A2245227F7E0F900617C10 /* AppCore.swift in Sources */,
 				127EBD78280A65960011C556 /* UINavigationController+extensions.swift in Sources */,
+				126E471028220181008D1554 /* AppleLoginService.swift in Sources */,
 				12A2245827F7E77700617C10 /* HomeCore.swift in Sources */,
 				1291296D27F814CD0017E087 /* ForEachWithIndex.swift in Sources */,
 				123EE075280452BE00D34B93 /* ListItemWithTextIcon.swift in Sources */,
@@ -756,6 +764,7 @@
 				125F84B2280D124F00279C42 /* AlertDoubleButtonCore.swift in Sources */,
 				123EE088280453AB00D34B93 /* SettingView.swift in Sources */,
 				125F84AC280D122500279C42 /* AlertSingleButtonCore.swift in Sources */,
+				12D7D3CD281E91EA00B83DDE /* UserService.swift in Sources */,
 				12952A61280250A300C89DD7 /* Font+extensions.swift in Sources */,
 				1214C0E3280E7A37002D2C4C /* LoginView.swift in Sources */,
 				1214C0E5280E7A42002D2C4C /* LoginCore.swift in Sources */,
@@ -922,8 +931,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.depromeet.mongsil;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mongsil;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -957,7 +967,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.depromeet.mongsil;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mongsil;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Mongsil/Mongsil/Application/AppCore.swift
+++ b/Mongsil/Mongsil/Application/AppCore.swift
@@ -15,10 +15,16 @@ struct AppState: Equatable {
 
 enum AppAction {
   case onAppear
+  case checkDisplayAppTrackingAlert
   case setShouldDisplayRequestAppTrackingAlert(Bool)
   case displayRequestAppTrackingAlert
+  case checkIsLogined
+  case checkHasKakaoToken
+  case checkHasAppleToken
+  case setIsLogined(Bool)
   case presentToast(String, Bool = true)
   case hideToast
+  case noop
 
   // Child Action
   case mainTab(MainTabAction)
@@ -28,14 +34,21 @@ struct AppEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
   var appTrackingService: AppTrackingService
   var kakaoLoginService: KakaoLoginService
+  var appleLoginService: AppleLoginService
+  var userService: UserService
+
   init(
     mainQueue: AnySchedulerOf<DispatchQueue>,
     appTrackingService: AppTrackingService,
-    kakaoLoginService: KakaoLoginService
+    kakaoLoginService: KakaoLoginService,
+    appleLoginService: AppleLoginService,
+    userService: UserService
   ) {
     self.mainQueue = mainQueue
     self.appTrackingService = appTrackingService
     self.kakaoLoginService = kakaoLoginService
+    self.appleLoginService = appleLoginService
+    self.userService = userService
   }
 }
 
@@ -46,7 +59,8 @@ let appReducer = Reducer.combine([
     environment: {
       MainTabEnvironment(
         mainQueue: $0.mainQueue,
-        kakaoLoginService: $0.kakaoLoginService
+        kakaoLoginService: $0.kakaoLoginService,
+        userService: $0.userService
       )
     }
   ) as Reducer<WithSharedState<AppState>, AppAction, AppEnvironment>,
@@ -56,6 +70,12 @@ let appReducer = Reducer.combine([
 
     switch action {
     case .onAppear:
+      return Effect.merge([
+        Effect(value: .checkDisplayAppTrackingAlert),
+        Effect(value: .checkIsLogined)
+      ])
+
+    case .checkDisplayAppTrackingAlert:
       return env.appTrackingService.getTrackingAuthorizationStatus()
         .map({ status -> AppAction in
           return .setShouldDisplayRequestAppTrackingAlert(status)
@@ -70,6 +90,41 @@ let appReducer = Reducer.combine([
     case .displayRequestAppTrackingAlert:
       return env.appTrackingService.requestAppTrackingAuthorization()
         .fireAndForget()
+
+    case .checkIsLogined:
+      let isKakao = UserDefaults.standard.bool(forKey: "isKakao")
+      return env.userService.isLogined()
+        .map({ isLogined -> AppAction in
+          if isLogined {
+            return isKakao ? .checkHasKakaoToken : .checkHasAppleToken
+          }
+          return .noop
+        })
+        .eraseToEffect()
+
+    case .checkHasKakaoToken:
+      return env.kakaoLoginService.hasKakaoToken()
+        .catchToEffect()
+        .flatMapLatest({ result -> Effect<AppAction, Never> in
+          switch result {
+          case .failure:
+            return Effect(value: .presentToast("카카오 로그인 연동 이력을 가져오는데 실패했습니다."))
+          case let .success(hasKakaoToken):
+            return Effect(value: .setIsLogined(hasKakaoToken))
+          }
+        })
+        .eraseToEffect()
+
+    case .checkHasAppleToken:
+      return env.appleLoginService.hasAppleToken()
+        .map({ result -> AppAction in
+          return .setIsLogined(result)
+        })
+        .eraseToEffect()
+
+    case let .setIsLogined(isLogined):
+      UserDefaults.standard.set(isLogined, forKey: "isLogined")
+      return .none
 
     case let .presentToast(toastText, isBottomPosition):
       state.shared.toastText = toastText
@@ -86,14 +141,13 @@ let appReducer = Reducer.combine([
       state.shared.toastText = nil
       return .none
 
-    case .mainTab(.login(.loginCompleted)):
-      state.shared.isLogined = true
-      return .none
-
     case let .mainTab(.login(.presentToast(text))):
       return Effect(value: .presentToast(text))
 
     case .mainTab:
+      return .none
+
+    case .noop:
       return .none
     }
   }

--- a/Mongsil/Mongsil/Application/AppCore.swift
+++ b/Mongsil/Mongsil/Application/AppCore.swift
@@ -25,7 +25,7 @@ enum AppAction {
   case presentToast(String, Bool = true)
   case hideToast
   case noop
-  
+
   // Child Action
   case mainTab(MainTabAction)
 }
@@ -67,7 +67,7 @@ let appReducer = Reducer.combine([
   Reducer<WithSharedState<AppState>, AppAction, AppEnvironment> {
     state, action, env in
     struct ToastCancelId: Hashable {}
-    
+
     switch action {
     case .onAppear:
       return Effect.merge([
@@ -82,11 +82,11 @@ let appReducer = Reducer.combine([
         })
         .delay(for: .milliseconds(100), scheduler: env.mainQueue)
         .eraseToEffect()
-      
+
     case let .setShouldDisplayRequestAppTrackingAlert(status):
       state.local.shouldDisplayRequestAppTrackingAlert = status
       return .none
-      
+
     case .displayRequestAppTrackingAlert:
       return env.appTrackingService.requestAppTrackingAuthorization()
         .fireAndForget()
@@ -125,7 +125,7 @@ let appReducer = Reducer.combine([
     case let .setIsLogined(isLogined):
       UserDefaults.standard.set(isLogined, forKey: "isLogined")
       return .none
-      
+
     case let .presentToast(toastText, isBottomPosition):
       state.shared.toastText = toastText
       state.shared.isToastBottomPosition = isBottomPosition
@@ -136,14 +136,14 @@ let appReducer = Reducer.combine([
           .eraseToEffect()
           .cancellable(id: ToastCancelId(), cancelInFlight: true)
       ])
-      
+
     case .hideToast:
       state.shared.toastText = nil
       return .none
-      
+
     case let .mainTab(.login(.presentToast(text))):
       return Effect(value: .presentToast(text))
-      
+
     case .mainTab:
       return .none
 

--- a/Mongsil/Mongsil/Application/AppDelegate.swift
+++ b/Mongsil/Mongsil/Application/AppDelegate.swift
@@ -12,7 +12,7 @@ import KakaoSDKAuth
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    KakaoSDK.initSDK(appKey: "ef5d13853714e6e7d452d31f1bc64186")
+    KakaoSDK.initSDK(appKey: "71b0a5fcc5d592aabb9593c9227b7b82")
     // Override point for customization after application launch.
     return true
   }

--- a/Mongsil/Mongsil/Application/AppView.swift
+++ b/Mongsil/Mongsil/Application/AppView.swift
@@ -12,7 +12,7 @@ struct AppView: View {
   private let store: Store<WithSharedState<AppState>, AppAction>
   private let shouldDisplayRequestAppTrackingAlertViewStore: ViewStore<Bool, AppAction>
   private let colorScheme: ColorScheme
-  
+
   init(
     store: Store<WithSharedState<AppState>, AppAction>,
     colorScheme: ColorScheme
@@ -23,7 +23,7 @@ struct AppView: View {
     )
     self.colorScheme = colorScheme
   }
-  
+
   var body: some View {
     ZStack {
       Theme.backgroundColor(scheme: colorScheme)

--- a/Mongsil/Mongsil/Application/SceneDelegate.swift
+++ b/Mongsil/Mongsil/Application/SceneDelegate.swift
@@ -20,7 +20,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     environment: AppEnvironment.init(
       mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
       appTrackingService: .init(),
-      kakaoLoginService: .init()
+      kakaoLoginService: .init(),
+      appleLoginService: .init(defaults: .standard),
+      userService: .init(defaults: .standard)
     )
   )
 

--- a/Mongsil/Mongsil/Application/SceneDelegate.swift
+++ b/Mongsil/Mongsil/Application/SceneDelegate.swift
@@ -11,9 +11,9 @@ import UIKit
 import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-  
+
   var window: UIWindow?
-  
+
   private lazy var appStore = Store<WithSharedState<AppState>, AppAction>(
     initialState: WithSharedState<AppState>(local: AppState(), shared: .init()),
     reducer: appReducer,
@@ -25,16 +25,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       userService: .init(defaults: .standard)
     )
   )
-  
+
   func scene(
     _ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions
   ) {
     // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
     // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
     // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-    
+
     // Create the SwiftUI view that provides the window contents.
-    
+
     // Use a UIHostingController as window root view controller.
     if let windowScene = scene as? UIWindowScene {
       let window = UIWindow(windowScene: windowScene)
@@ -48,7 +48,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       window.makeKeyAndVisible()
     }
   }
-  
+
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
     if let url = URLContexts.first?.url {
       if AuthApi.isKakaoTalkLoginUrl(url) {
@@ -56,33 +56,33 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       }
     }
   }
-  
+
   func sceneDidDisconnect(_ scene: UIScene) {
     // Called as the scene is being released by the system.
     // This occurs shortly after the scene enters the background, or when its session is discarded.
     // Release any resources associated with this scene that can be re-created the next time the scene connects.
     // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
   }
-  
+
   func sceneDidBecomeActive(_ scene: UIScene) {
     // Called when the scene has moved from an inactive state to an active state.
     // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
   }
-  
+
   func sceneWillResignActive(_ scene: UIScene) {
     // Called when the scene will move from an active state to an inactive state.
     // This may occur due to temporary interruptions (ex. an incoming phone call).
   }
-  
+
   func sceneWillEnterForeground(_ scene: UIScene) {
     // Called as the scene transitions from the background to the foreground.
     // Use this method to undo the changes made on entering the background.
   }
-  
+
   func sceneDidEnterBackground(_ scene: UIScene) {
     // Called as the scene transitions from the foreground to the background.
     // Use this method to save data, release shared resources, and store enough scene-specific state information
     // to restore the scene back to its current state.
   }
-  
+
 }

--- a/Mongsil/Mongsil/Info.plist
+++ b/Mongsil/Mongsil/Info.plist
@@ -9,7 +9,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakaoef5d13853714e6e7d452d31f1bc64186</string>
+				<string>kakao71b0a5fcc5d592aabb9593c9227b7b82</string>
 			</array>
 		</dict>
 	</array>

--- a/Mongsil/Mongsil/Module/Component/Models/Dream.swift
+++ b/Mongsil/Mongsil/Module/Component/Models/Dream.swift
@@ -9,12 +9,12 @@ import Foundation
 
 public struct Dream: Decodable {
   public let category: [String: [Subcategory]]
-  
+
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     category = try values.decode([String: [Subcategory]].self, forKey: .category)
   }
-  
+
   public enum CodingKeys: String, CodingKey {
     case category
   }

--- a/Mongsil/Mongsil/Module/Component/Models/DreamInfo.swift
+++ b/Mongsil/Mongsil/Module/Component/Models/DreamInfo.swift
@@ -10,13 +10,13 @@ import Foundation
 public struct DreamInfo: Decodable {
   public let title: String
   public let description: String
-  
+
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     title = try values.decode(String.self, forKey: .title)
     description = try values.decode(String.self, forKey: .description)
   }
-  
+
   public enum CodingKeys: String, CodingKey {
     case title = "dream"
     case description = "translate"

--- a/Mongsil/Mongsil/Module/Component/Models/Subcategory.swift
+++ b/Mongsil/Mongsil/Module/Component/Models/Subcategory.swift
@@ -9,12 +9,12 @@ import Foundation
 
 public struct Subcategory: Decodable {
   public let subcategory: [String: [DreamInfo]]
-  
+
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     subcategory = try values.decode([String: [DreamInfo]].self, forKey: .subcategory)
   }
-  
+
   public enum CodingKeys: String, CodingKey {
     case subcategory
   }

--- a/Mongsil/Mongsil/Module/Component/Models/User.swift
+++ b/Mongsil/Mongsil/Module/Component/Models/User.swift
@@ -10,13 +10,13 @@ import Foundation
 public struct User: Decodable {
   public let name: String?
   public let email: String?
-  
+
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     name = try values.decodeIfPresent(String.self, forKey: .name)
     email = try values.decodeIfPresent(String.self, forKey: .email)
   }
-  
+
   public enum CodingKeys: String, CodingKey {
     case name
     case email

--- a/Mongsil/Mongsil/Module/Component/Services/AppleLoginService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/AppleLoginService.swift
@@ -1,0 +1,46 @@
+//
+//  AppleLoginService.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/04.
+//
+
+import AuthenticationServices
+import Combine
+
+public class AppleLoginService {
+  public var defaults: UserDefaults
+
+  public init(
+    defaults: UserDefaults
+  ) {
+    self.defaults = defaults
+  }
+
+  public func hasAppleToken() -> AnyPublisher<Bool, Never> {
+    return Publishers.Create<Bool, Never>(factory: { [unowned self] subscribers -> Cancellable in
+      guard let userID = self.defaults.string(forKey: "appleUserID") else {
+        subscribers.send(false)
+        subscribers.send(completion: .finished)
+        return AnyCancellable({})
+      }
+
+      let appleIDProvider = ASAuthorizationAppleIDProvider()
+      appleIDProvider.getCredentialState(forUserID: userID) { (credentialState, error) in
+        if error != nil {
+          subscribers.send(false)
+        } else {
+          switch credentialState {
+          case .authorized:
+            subscribers.send(true)
+          default:
+            subscribers.send(false)
+          }
+        }
+        subscribers.send(completion: .finished)
+      }
+      return AnyCancellable({})
+    })
+    .eraseToAnyPublisher()
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/KakaoLoginService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/KakaoLoginService.swift
@@ -7,6 +7,8 @@
 
 import Combine
 import KakaoSDKUser
+import KakaoSDKAuth
+import KakaoSDKCommon
 
 public class KakaoLoginService {
   public init() {}
@@ -71,6 +73,40 @@ public class KakaoLoginService {
           let email = user.kakaoAccount?.email ?? ""
           completion(.success(["nickName": nickName, "email": email]))
         }
+      }
+    }
+  }
+
+  public func hasKakaoToken() -> AnyPublisher<Bool, Error> {
+    return Publishers.Create<Bool, Error>(factory: { [unowned self] subscribers -> Cancellable in
+      if AuthApi.hasToken() {
+        self.accessTokenInfo { result in
+          switch result {
+          case let .success(hasKakaoToken):
+            subscribers.send(hasKakaoToken)
+          case let .failure(error):
+            subscribers.send(completion: .failure(error))
+          }
+        }
+      } else {
+        subscribers.send(false)
+      }
+      subscribers.send(completion: .finished)
+      return AnyCancellable({})
+    })
+    .eraseToAnyPublisher()
+  }
+
+  private func accessTokenInfo(completion: @escaping (Result<Bool, Error>) -> Void) {
+    UserApi.shared.accessTokenInfo { _, error in
+      if let error = error {
+        if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
+          completion(.failure(error))
+        } else {
+          completion(.failure(error))
+        }
+      } else {
+        completion(.success(true))
       }
     }
   }

--- a/Mongsil/Mongsil/Module/Component/Services/KakaoLoginService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/KakaoLoginService.swift
@@ -2,7 +2,7 @@
 //  KakaoLoginService.swift
 //  Mongsil
 //
-//  Created by Chuljin Hwang on 2022/04/09.
+//  Created by Chanwoo Cho on 2022/04/09.
 //
 
 import Combine

--- a/Mongsil/Mongsil/Module/Component/Services/UserService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/UserService.swift
@@ -1,0 +1,75 @@
+//
+//  UserService.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/01.
+//
+
+import Combine
+import CombineExt
+
+public class UserService {
+  public var defaults: UserDefaults
+
+  public init(
+    defaults: UserDefaults
+  ) {
+    self.defaults = defaults
+  }
+
+  public func isLogined() -> AnyPublisher<Bool, Never> {
+    return Publishers.Create<Bool, Never>(factory: { [unowned self] subscribers -> Cancellable in
+      if self.defaults.object(forKey: "isLogined") == nil {
+        subscribers.send(false)
+      } else {
+        subscribers.send(true)
+      }
+      subscribers.send(completion: .finished)
+      return AnyCancellable({})
+    })
+    .eraseToAnyPublisher()
+  }
+
+  public func setLoginInfo(
+    isLogined: Bool,
+    isKakao: Bool,
+    name: String,
+    email: String,
+    userID: String? = nil
+  ) -> AnyPublisher<Void, Never> {
+    return Publishers.Create<Void, Never>(factory: { [unowned self] subscribers -> Cancellable in
+      subscribers.send(
+        self.setUserDefaults(
+          isLogined: isLogined,
+          isKakao: isKakao,
+          name: name,
+          email: email,
+          userID: userID
+        )
+      )
+      subscribers.send(completion: .finished)
+      return AnyCancellable({})
+    })
+    .eraseToAnyPublisher()
+  }
+
+  private func setUserDefaults(
+    isLogined: Bool,
+    isKakao: Bool,
+    name: String,
+    email: String,
+    userID: String? = nil
+  ) {
+    self.defaults.set(isLogined, forKey: "isLogined")
+    if isKakao {
+      self.defaults.set(isKakao, forKey: "isKakao")
+      self.defaults.set(name, forKey: "kakaoName")
+      self.defaults.set(email, forKey: "kakaoEmail")
+    } else {
+      self.defaults.set(isKakao, forKey: "isKakao")
+      self.defaults.set(name, forKey: "appleName")
+      self.defaults.set(email, forKey: "appleEmail")
+      self.defaults.set(userID, forKey: "appleUserID")
+    }
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/SharedState/SharedState.swift
+++ b/Mongsil/Mongsil/Module/Component/SharedState/SharedState.swift
@@ -45,14 +45,11 @@ public struct WithSharedState<LocalState: Equatable>: Equatable {
 public struct SharedState: Equatable {
   public var toastText: String?
   public var isToastBottomPosition: Bool = true
-  public var isLogined: Bool = false
 
   public init(
-    toastText: String? = nil,
-    isLogined: Bool = false
+    toastText: String? = nil
   ) {
     self.toastText = toastText
-    self.isLogined = isLogined
   }
 
 }

--- a/Mongsil/Mongsil/Module/Component/Views/TabView/MSTabView.swift
+++ b/Mongsil/Mongsil/Module/Component/Views/TabView/MSTabView.swift
@@ -11,9 +11,9 @@ public struct MSTabView<Selection>: View where Selection: Hashable & Identifiabl
   public var icons: [Selection: Image]
   public var titles: [Selection: String]
   public var views: [Selection: AnyView]
-  
+
   @Binding public var selection: Selection
-  
+
   public init(
     icons: [Selection: Image],
     titles: [Selection: String],
@@ -25,13 +25,13 @@ public struct MSTabView<Selection>: View where Selection: Hashable & Identifiabl
     self.views = views
     self._selection = selection
   }
-  
+
   public var body: some View {
     VStack(spacing: 0) {
       views[selection]
-      
+
       Spacer(minLength: 0)
-      
+
       HStack(spacing: 0) {
         ForEach(
           views.keys.sorted(),
@@ -58,19 +58,19 @@ private struct MSTab: View {
   var title: String
   var selected: Bool
   var action: () -> Void
-  
+
   var backgroundColor: Color {
     selected ? .gray10 : .gray11
   }
   var foregroundColor: Color {
     selected ? .msWhite : .gray1
   }
-  
+
   let keyWindow = UIApplication.shared.connectedScenes
     .compactMap { $0 as? UIWindowScene }
     .flatMap { $0.windows }
     .first { $0.isKeyWindow }
-  
+
   var body: some View {
     Button(action: action) {
       VStack(spacing: 5) {

--- a/Mongsil/Mongsil/Module/Feature/MainTab/MainTabView.swift
+++ b/Mongsil/Mongsil/Module/Feature/MainTab/MainTabView.swift
@@ -10,12 +10,12 @@ import ComposableArchitecture
 
 struct MainTabView: View {
   private let store: Store<WithSharedState<MainTabState>, MainTabAction>
-  
+
   init(store: Store<WithSharedState<MainTabState>, MainTabAction>) {
     self.store = store
     UITabBar.appearance().scrollEdgeAppearance = .init()
   }
-  
+
   var body: some View {
     GeometryReader { metrics in
       WithViewStore(store.scope(state: \.local.selectedTab)) { selectedTabViewStore in
@@ -58,25 +58,25 @@ struct MainTabView: View {
 
 private struct RecordButtonView: View {
   private let store: Store<WithSharedState<MainTabState>, MainTabAction>
-  
+
   init(store: Store<WithSharedState<MainTabState>, MainTabAction>) {
     self.store = store
   }
-  
+
   var body: some View {
     RecordLink(store: store)
     LoginLink(store: store)
-    
+
   }
 }
 
 private struct RecordLink: View {
   private let store: Store<WithSharedState<MainTabState>, MainTabAction>
-  
+
   init(store: Store<WithSharedState<MainTabState>, MainTabAction>) {
     self.store = store
   }
-  
+
   var body: some View {
     WithViewStore(store.scope(state: \.local.isRecordPushed)) { isRecordPushedViewStore in
       NavigationLink(
@@ -101,11 +101,11 @@ private struct RecordLink: View {
 
 private struct LoginLink: View {
   private let store: Store<WithSharedState<MainTabState>, MainTabAction>
-  
+
   init(store: Store<WithSharedState<MainTabState>, MainTabAction>) {
     self.store = store
   }
-  
+
   var body: some View {
     WithViewStore(store.scope(state: \.local.isLoginPushed)) { isLoginPushedViewStore in
       NavigationLink(

--- a/Mongsil/Mongsil/Mongsil.entitlements
+++ b/Mongsil/Mongsil/Mongsil.entitlements
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/Mongsil/generated/R.generated.swift
+++ b/Mongsil/generated/R.generated.swift
@@ -51,8 +51,7 @@ struct R: Rswift.Validatable {
     // Note: key might not exist in chosen language (in that case, key will be shown)
     for language in languages {
       if let lproj = hostingBundle.url(forResource: language, withExtension: "lproj"),
-         let lbundle = Bundle(url: lproj)
-      {
+         let lbundle = Bundle(url: lproj) {
         let strings = lbundle.url(forResource: tableName, withExtension: "strings")
         let stringsdict = lbundle.url(forResource: tableName, withExtension: "stringsdict")
 
@@ -437,6 +436,19 @@ struct R: Rswift.Validatable {
     fileprivate init() {}
   }
 
+  /// This `R.entitlements` struct is generated, and contains static references to 2 properties.
+  struct entitlements {
+    static let apsEnvironment = infoPlistString(path: [], key: "aps-environment") ?? "development"
+
+    struct comAppleDeveloperApplesignin {
+      static let `default` = infoPlistString(path: ["com.apple.developer.applesignin"], key: "Default") ?? "Default"
+
+      fileprivate init() {}
+    }
+
+    fileprivate init() {}
+  }
+
   /// This `R.file` struct is generated, and contains static references to 3 files.
   struct file {
     /// Resource file `Pretendard-Medium.ttf`.
@@ -492,9 +504,9 @@ struct R: Rswift.Validatable {
     }
 
     static func validate() throws {
-      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
     }
 
     fileprivate init() {}

--- a/Mongsil/generated/R.generated.swift
+++ b/Mongsil/generated/R.generated.swift
@@ -51,7 +51,8 @@ struct R: Rswift.Validatable {
     // Note: key might not exist in chosen language (in that case, key will be shown)
     for language in languages {
       if let lproj = hostingBundle.url(forResource: language, withExtension: "lproj"),
-         let lbundle = Bundle(url: lproj) {
+         let lbundle = Bundle(url: lproj)
+      {
         let strings = lbundle.url(forResource: tableName, withExtension: "strings")
         let stringsdict = lbundle.url(forResource: tableName, withExtension: "stringsdict")
 
@@ -504,9 +505,9 @@ struct R: Rswift.Validatable {
     }
 
     static func validate() throws {
-      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
     }
 
     fileprivate init() {}


### PR DESCRIPTION
### Task
- 애플 로그인 연동 구현
- 카카오/애플 기존 계정 연동 해제 및 새 계정 연동
- 소셜 로그인 시 UserDefaults 데이터 저장 (추후 회원가입/조회/탈퇴 API 연동에 활용)

### Description
- 일차적으로 기존 이탈 인원이 설정한 카카오/애플 계정에 대해 새 발급 및 설정 절차를 완료했습니다.
- 애플 로그인을 구현했습니다.
- 카카오/애플 로그인에 대해 기존 연동 이력에 대한 검증 로직을 추가했습니다.
- 소셜 로그인 시 로컬 데이터 활용을 위해 카카오인지 애플인지 그리고 닉네임/이메일 등 필요한 정보들을 UserDefaults에 저장하도록 구현했습니다.
이는 추후 회원 및 꿈에 대해 서버 통신 시 전역적인 부분에서 request로 넘겨줄 예정입니다.
- Bundle Identifier등이 기존과 동일하게 사용할 수 없어 많이 바뀐 부분이 있습니다.
이에 해당 PR이 머지되면 꼭 메인에서 브랜치따서 작업하시는걸 추천드립니다! (컨플릭이 심할거에요 기존에 하던거랑 병합하면ㅠ)

### 시뮬레이터 영상
시뮬레이터 14 이상부터 애플의 버그로 정상적으로 애플 로그인이 되지 않습니다.
이에 제 디바이스에서 실행한 영상을 첨부드립니다..!
<img src="https://user-images.githubusercontent.com/72292617/166613021-54e8e671-5413-4159-8dd3-2f90fec62506.gif" width="350" height="700">

