### PR TITLE
feat: Add User Service API

### DIFF
--- a/Mongsil/Mongsil.xcodeproj/project.pbxproj
+++ b/Mongsil/Mongsil.xcodeproj/project.pbxproj
@@ -58,6 +58,17 @@
 		1291296A27F813660017E087 /* Combine+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1291296927F813660017E087 /* Combine+extensions.swift */; };
 		1291296D27F814CD0017E087 /* ForEachWithIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1291296C27F814CD0017E087 /* ForEachWithIndex.swift */; };
 		1291296F27F815460017E087 /* SharedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1291296E27F815460017E087 /* SharedState.swift */; };
+		1292B17F28248D270050A10D /* URLHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B17E28248D270050A10D /* URLHost.swift */; };
+		1292B182282491EF0050A10D /* CommonResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B181282491EF0050A10D /* CommonResponseDto.swift */; };
+		1292B1852824938D0050A10D /* CheckUserDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B1842824938D0050A10D /* CheckUserDto.swift */; };
+		1292B187282494760050A10D /* SignUpUserDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B186282494760050A10D /* SignUpUserDto.swift */; };
+		1292B189282495030050A10D /* SignUpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B188282495030050A10D /* SignUpService.swift */; };
+		1292B18B282497B30050A10D /* CheckUserRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B18A282497B30050A10D /* CheckUserRequestDto.swift */; };
+		1292B18E282498510050A10D /* SignUpUserRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B18D282498510050A10D /* SignUpUserRequestDto.swift */; };
+		1292B190282498940050A10D /* DropoutRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B18F282498940050A10D /* DropoutRequestDto.swift */; };
+		1292B192282499ED0050A10D /* ErrorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B191282499ED0050A10D /* ErrorFactory.swift */; };
+		1292B19528249D0F0050A10D /* DropoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B19428249D0F0050A10D /* DropoutService.swift */; };
+		1292B19728249E7C0050A10D /* Unit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292B19628249E7C0050A10D /* Unit.swift */; };
 		12952A61280250A300C89DD7 /* Font+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12952A60280250A300C89DD7 /* Font+extensions.swift */; };
 		12952A63280250D700C89DD7 /* UIFont+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12952A62280250D700C89DD7 /* UIFont+extensions.swift */; };
 		12952A65280251D600C89DD7 /* Fonts+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12952A64280251D600C89DD7 /* Fonts+Generated.swift */; };
@@ -144,6 +155,17 @@
 		1291296927F813660017E087 /* Combine+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+extensions.swift"; sourceTree = "<group>"; };
 		1291296C27F814CD0017E087 /* ForEachWithIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachWithIndex.swift; sourceTree = "<group>"; };
 		1291296E27F815460017E087 /* SharedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedState.swift; sourceTree = "<group>"; };
+		1292B17E28248D270050A10D /* URLHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHost.swift; sourceTree = "<group>"; };
+		1292B181282491EF0050A10D /* CommonResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResponseDto.swift; sourceTree = "<group>"; };
+		1292B1842824938D0050A10D /* CheckUserDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserDto.swift; sourceTree = "<group>"; };
+		1292B186282494760050A10D /* SignUpUserDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUserDto.swift; sourceTree = "<group>"; };
+		1292B188282495030050A10D /* SignUpService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpService.swift; sourceTree = "<group>"; };
+		1292B18A282497B30050A10D /* CheckUserRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserRequestDto.swift; sourceTree = "<group>"; };
+		1292B18D282498510050A10D /* SignUpUserRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUserRequestDto.swift; sourceTree = "<group>"; };
+		1292B18F282498940050A10D /* DropoutRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropoutRequestDto.swift; sourceTree = "<group>"; };
+		1292B191282499ED0050A10D /* ErrorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorFactory.swift; sourceTree = "<group>"; };
+		1292B19428249D0F0050A10D /* DropoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropoutService.swift; sourceTree = "<group>"; };
+		1292B19628249E7C0050A10D /* Unit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unit.swift; sourceTree = "<group>"; };
 		12952A60280250A300C89DD7 /* Font+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+extensions.swift"; sourceTree = "<group>"; };
 		12952A62280250D700C89DD7 /* UIFont+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+extensions.swift"; sourceTree = "<group>"; };
 		12952A64280251D600C89DD7 /* Fonts+Generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fonts+Generated.swift"; sourceTree = "<group>"; };
@@ -369,10 +391,15 @@
 		12457C0727F822D300F2DBF2 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				1292B18028248F090050A10D /* URL */,
+				1292B18C282497B80050A10D /* RequestDto */,
+				1292B183282491F60050A10D /* ResponseDto */,
 				F03FF6CA28099B7900E83570 /* KakaoLoginService.swift */,
 				126E470F28220181008D1554 /* AppleLoginService.swift */,
 				12273EEF27F91076007624C1 /* AppTrackingService.swift */,
 				12D7D3CC281E91EA00B83DDE /* UserService.swift */,
+				1292B188282495030050A10D /* SignUpService.swift */,
+				1292B19428249D0F0050A10D /* DropoutService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -455,6 +482,7 @@
 				1291296827F813340017E087 /* ComposableArchitecture */,
 				123EE07E2804531000D34B93 /* Combine */,
 				123EE07D2804530500D34B93 /* View */,
+				1292B19628249E7C0050A10D /* Unit.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -489,6 +517,42 @@
 				1291296E27F815460017E087 /* SharedState.swift */,
 			);
 			path = SharedState;
+			sourceTree = "<group>";
+		};
+		1292B18028248F090050A10D /* URL */ = {
+			isa = PBXGroup;
+			children = (
+				1292B17E28248D270050A10D /* URLHost.swift */,
+			);
+			path = URL;
+			sourceTree = "<group>";
+		};
+		1292B183282491F60050A10D /* ResponseDto */ = {
+			isa = PBXGroup;
+			children = (
+				1292B181282491EF0050A10D /* CommonResponseDto.swift */,
+				1292B1842824938D0050A10D /* CheckUserDto.swift */,
+				1292B186282494760050A10D /* SignUpUserDto.swift */,
+			);
+			path = ResponseDto;
+			sourceTree = "<group>";
+		};
+		1292B18C282497B80050A10D /* RequestDto */ = {
+			isa = PBXGroup;
+			children = (
+				1292B18A282497B30050A10D /* CheckUserRequestDto.swift */,
+				1292B18D282498510050A10D /* SignUpUserRequestDto.swift */,
+				1292B18F282498940050A10D /* DropoutRequestDto.swift */,
+			);
+			path = RequestDto;
+			sourceTree = "<group>";
+		};
+		1292B193282499FB0050A10D /* ErrorHandling */ = {
+			isa = PBXGroup;
+			children = (
+				1292B191282499ED0050A10D /* ErrorFactory.swift */,
+			);
+			path = ErrorHandling;
 			sourceTree = "<group>";
 		};
 		12A2244E27F7E0D500617C10 /* Application */ = {
@@ -541,6 +605,7 @@
 				12457C0727F822D300F2DBF2 /* Services */,
 				1291297027F816570017E087 /* SharedState */,
 				1291296327F8129C0017E087 /* Extensions */,
+				1292B193282499FB0050A10D /* ErrorHandling */,
 				1291296B27F814920017E087 /* Views */,
 			);
 			path = Component;
@@ -732,17 +797,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				773AE2B028072421006861FC /* StorageCore.swift in Sources */,
+				1292B1852824938D0050A10D /* CheckUserDto.swift in Sources */,
 				123EE0852804537B00D34B93 /* RightButton.swift in Sources */,
 				1291296727F812FE0017E087 /* Reducer+extensions.swift in Sources */,
 				12A2245227F7E0F900617C10 /* AppCore.swift in Sources */,
 				127EBD78280A65960011C556 /* UINavigationController+extensions.swift in Sources */,
+				1292B190282498940050A10D /* DropoutRequestDto.swift in Sources */,
+				1292B187282494760050A10D /* SignUpUserDto.swift in Sources */,
 				126E471028220181008D1554 /* AppleLoginService.swift in Sources */,
 				12A2245827F7E77700617C10 /* HomeCore.swift in Sources */,
 				1291296D27F814CD0017E087 /* ForEachWithIndex.swift in Sources */,
 				123EE075280452BE00D34B93 /* ListItemWithTextIcon.swift in Sources */,
 				773AE2AE28072419006861FC /* StorageView.swift in Sources */,
 				12952A65280251D600C89DD7 /* Fonts+Generated.swift in Sources */,
+				1292B19528249D0F0050A10D /* DropoutService.swift in Sources */,
 				120BBCB028025DA500AD44B5 /* Colors+Generated.swift in Sources */,
+				1292B192282499ED0050A10D /* ErrorFactory.swift in Sources */,
 				123EE093280453EA00D34B93 /* AppInfoCore.swift in Sources */,
 				123EE0A528045F8300D34B93 /* OpenSourceCore.swift in Sources */,
 				12273EF027F91076007624C1 /* AppTrackingService.swift in Sources */,
@@ -765,6 +835,7 @@
 				12A2245627F7E76F00617C10 /* HomeView.swift in Sources */,
 				773AE2AC280723FF006861FC /* RecordCore.swift in Sources */,
 				1291296A27F813660017E087 /* Combine+extensions.swift in Sources */,
+				1292B19728249E7C0050A10D /* Unit.swift in Sources */,
 				123EE09928045F0C00D34B93 /* TermsView.swift in Sources */,
 				123DD56928028A130020440E /* UIImage+extensions.swift in Sources */,
 				125F84B0280D124700279C42 /* AlertSingleButtonView.swift in Sources */,
@@ -785,10 +856,12 @@
 				1214C0E5280E7A42002D2C4C /* LoginCore.swift in Sources */,
 				123EE08D280453D200D34B93 /* ProfileView.swift in Sources */,
 				12EF96B028195DF2002CEFFA /* MSTabView.swift in Sources */,
+				1292B182282491EF0050A10D /* CommonResponseDto.swift in Sources */,
 				123DD564280283410020440E /* Theme.swift in Sources */,
 				7779D722281C07BF00683C1F /* Subcategory.swift in Sources */,
 				F03FF6CB28099B7900E83570 /* KakaoLoginService.swift in Sources */,
 				123DD5662802889D0020440E /* Image+Generated.swift in Sources */,
+				1292B189282495030050A10D /* SignUpService.swift in Sources */,
 				123EE0A028045F5700D34B93 /* PersonalInfoPolicyCore.swift in Sources */,
 				123EE08F280453D900D34B93 /* ProfileCore.swift in Sources */,
 				123EE077280452C900D34B93 /* ListItemWithText.swift in Sources */,
@@ -796,7 +869,10 @@
 				120BBCB228025E3200AD44B5 /* Color+extensions.swift in Sources */,
 				773AE2A6280723DC006861FC /* MainTabView.swift in Sources */,
 				123EE07C2804530000D34B93 /* View+extensions.swift in Sources */,
+				1292B18B282497B30050A10D /* CheckUserRequestDto.swift in Sources */,
+				1292B17F28248D270050A10D /* URLHost.swift in Sources */,
 				123EE09B28045F1500D34B93 /* TermsCore.swift in Sources */,
+				1292B18E282498510050A10D /* SignUpUserRequestDto.swift in Sources */,
 				12A2244D27F7E04A00617C10 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Mongsil/Mongsil/Application/AppCore.swift
+++ b/Mongsil/Mongsil/Application/AppCore.swift
@@ -36,19 +36,22 @@ struct AppEnvironment {
   var kakaoLoginService: KakaoLoginService
   var appleLoginService: AppleLoginService
   var userService: UserService
+  var signUpService: SignUpService
 
   init(
     mainQueue: AnySchedulerOf<DispatchQueue>,
     appTrackingService: AppTrackingService,
     kakaoLoginService: KakaoLoginService,
     appleLoginService: AppleLoginService,
-    userService: UserService
+    userService: UserService,
+    signUpService: SignUpService
   ) {
     self.mainQueue = mainQueue
     self.appTrackingService = appTrackingService
     self.kakaoLoginService = kakaoLoginService
     self.appleLoginService = appleLoginService
     self.userService = userService
+    self.signUpService = signUpService
   }
 }
 
@@ -60,7 +63,8 @@ let appReducer = Reducer.combine([
       MainTabEnvironment(
         mainQueue: $0.mainQueue,
         kakaoLoginService: $0.kakaoLoginService,
-        userService: $0.userService
+        userService: $0.userService,
+        signUpService: $0.signUpService
       )
     }
   ) as Reducer<WithSharedState<AppState>, AppAction, AppEnvironment>,

--- a/Mongsil/Mongsil/Application/SceneDelegate.swift
+++ b/Mongsil/Mongsil/Application/SceneDelegate.swift
@@ -22,7 +22,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       appTrackingService: .init(),
       kakaoLoginService: .init(),
       appleLoginService: .init(defaults: .standard),
-      userService: .init(defaults: .standard)
+      userService: .init(
+        defaults: .standard,
+        alamofireSession: .default
+      ),
+      signUpService: .init(alamofireSession: .default)
     )
   )
 

--- a/Mongsil/Mongsil/Module/Component/ErrorHandling/ErrorFactory.swift
+++ b/Mongsil/Mongsil/Module/Component/ErrorHandling/ErrorFactory.swift
@@ -1,0 +1,17 @@
+//
+//  ErrorFactory.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Foundation
+
+public protocol ErrorFactory {
+  static var domain: String { get }
+  associatedtype Code: RawRepresentable where Code.RawValue == Int
+}
+
+extension ErrorFactory {
+  public static var domain: String { "\(Self.self)" }
+}

--- a/Mongsil/Mongsil/Module/Component/Extensions/Unit.swift
+++ b/Mongsil/Mongsil/Module/Component/Extensions/Unit.swift
@@ -1,0 +1,13 @@
+//
+//  Unit.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Foundation
+
+/// Same with `Void`, but conforms Equatable
+public struct Unit: Equatable {
+  public init() {}
+}

--- a/Mongsil/Mongsil/Module/Component/Services/DropoutService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/DropoutService.swift
@@ -1,0 +1,104 @@
+//
+//  DropoutService.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Alamofire
+import Combine
+import CombineExt
+
+public class DropoutService {
+  public typealias ErrorFactory = DropoutServiceErrorFactory
+
+  public let alamofireSession: Session
+
+  public init(alamofireSession: Session) {
+    self.alamofireSession = alamofireSession
+  }
+
+  public func dropout(id: String) -> AnyPublisher<Unit, Error> {
+    let url = "3.34.46.139:3000\(URLHost.dropout)"
+    let body = DropoutRequestDto(userId: id)
+
+    return alamofireSession.request(
+      url,
+      method: .delete,
+      parameters: body,
+      encoder: JSONParameterEncoder.default
+    )
+    .validate(statusCode: 200..<300)
+    .publishData()
+    .tryMap({ dataResponse -> CommonResponseDto.NotExistData in
+      switch dataResponse.result {
+      case let .success(data):
+        do {
+          return try JSONDecoder().decode(CommonResponseDto.NotExistData.self, from: data)
+        } catch {
+          throw ErrorFactory.decodeFailed(
+            url: url,
+            data: data,
+            underlying: error
+          )
+        }
+      case let .failure(error):
+        throw ErrorFactory.dropoutFailed(url: url, underlying: error)
+      }
+    })
+    .tryMap({ response -> CommonResponseDto.NotExistData in
+      if response.statusCode == "200" {
+        return response
+      } else {
+        throw ErrorFactory.dropoutFailed(
+          url: url,
+          statusCode: response.statusCode,
+          underlying: nil
+        )
+      }
+    })
+    .mapTo(Unit())
+    .eraseToAnyPublisher()
+  }
+}
+
+public enum DropoutServiceErrorFactory: ErrorFactory {
+  public enum Code: Int {
+    case decodeFailed = 1
+    case dropoutFailed = 2
+  }
+
+  public static func decodeFailed(
+    url: String,
+    data: Data,
+    underlying: Error
+  ) -> NSError {
+    return NSError(
+      domain: domain,
+      code: Code.decodeFailed.rawValue,
+      userInfo: [
+        "identifier": String(reflecting: Code.decodeFailed),
+        "url": url,
+        "data": data,
+        NSUnderlyingErrorKey: underlying
+      ]
+    )
+  }
+
+  public static func dropoutFailed(
+    url: String,
+    statusCode: String? = nil,
+    underlying: Error? = nil
+  ) -> NSError {
+    return NSError(
+      domain: domain,
+      code: Code.dropoutFailed.rawValue,
+      userInfo: [
+        "identifier": String(reflecting: Code.dropoutFailed),
+        "url": url,
+        "statusCode": statusCode as Any,
+        NSUnderlyingErrorKey: underlying as Any
+      ]
+    )
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/DropoutService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/DropoutService.swift
@@ -19,7 +19,7 @@ public class DropoutService {
   }
 
   public func dropout(id: String) -> AnyPublisher<Unit, Error> {
-    let url = "3.34.46.139:3000\(URLHost.dropout)"
+    let url = "http://3.34.46.139:3000\(URLHost.dropout)"
     let body = DropoutRequestDto(userId: id)
 
     return alamofireSession.request(

--- a/Mongsil/Mongsil/Module/Component/Services/RequestDto/CheckUserRequestDto.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/RequestDto/CheckUserRequestDto.swift
@@ -1,0 +1,21 @@
+//
+//  CheckUserRequestDto.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Foundation
+
+public struct CheckUserRequestDto: Encodable {
+  public var userEmail: String
+
+  enum CodingKeys: String, CodingKey {
+    case userEmail
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(userEmail, forKey: .userEmail)
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/RequestDto/DropoutRequestDto.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/RequestDto/DropoutRequestDto.swift
@@ -1,0 +1,21 @@
+//
+//  DropoutRequestDto.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Foundation
+
+public struct DropoutRequestDto: Encodable {
+  public var userId: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(userId, forKey: .userId)
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/RequestDto/SignUpUserRequestDto.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/RequestDto/SignUpUserRequestDto.swift
@@ -1,0 +1,23 @@
+//
+//  SignUpUserRequestDto.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Foundation
+
+public struct SignUpUserRequestDto: Encodable {
+  public var userEmail: String
+  public var userName: String
+
+  enum CodingKeys: String, CodingKey {
+    case userEmail, userName
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(userEmail, forKey: .userEmail)
+    try container.encode(userName, forKey: .userName)
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/ResponseDto/CheckUserDto.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/ResponseDto/CheckUserDto.swift
@@ -1,0 +1,23 @@
+//
+//  CheckUserResponseDto.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Foundation
+
+public struct CheckUserResponseDto: Decodable {
+  public let checkValue: Bool
+  public let userId: String?
+
+  public enum CodingKeys: String, CodingKey {
+    case checkValue, userId
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.checkValue = try container.decode(Bool.self, forKey: .checkValue)
+    self.userId = try container.decodeIfPresent(String.self, forKey: .userId)
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/ResponseDto/CommonResponseDto.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/ResponseDto/CommonResponseDto.swift
@@ -1,0 +1,40 @@
+//
+//  CommonResponseDto.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+public enum CommonResponseDto {
+  public struct ExistData<T: Decodable>: Decodable {
+    public var statusCode: String
+    public var message: String
+    public var data: T?
+
+    public enum CodingKeys: String, CodingKey {
+      case statusCode, message, data
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.statusCode = try container.decode(String.self, forKey: .statusCode)
+      self.message = try container.decode(String.self, forKey: .message)
+      self.data = try container.decode(T?.self, forKey: .data)
+    }
+  }
+
+  public struct NotExistData: Decodable {
+    public var statusCode: String
+    public var message: String
+
+    public enum CodingKeys: String, CodingKey {
+      case statusCode, message
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.statusCode = try container.decode(String.self, forKey: .statusCode)
+      self.message = try container.decode(String.self, forKey: .message)
+    }
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/ResponseDto/SignUpUserDto.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/ResponseDto/SignUpUserDto.swift
@@ -1,0 +1,21 @@
+//
+//  SignUpUserResponseDto.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Foundation
+
+public struct SignUpUserResponseDto: Decodable {
+  public let userId: String
+
+  public enum CodingKeys: String, CodingKey {
+    case userId
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.userId = try container.decode(String.self, forKey: .userId)
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/SignUpService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/SignUpService.swift
@@ -19,7 +19,7 @@ public class SignUpService {
   }
 
   public func singUp(name: String, with email: String) -> AnyPublisher<SignUpUserResponseDto, Error> {
-    let url = "3.34.46.139:3000\(URLHost.signUp)"
+    let url = "http://3.34.46.139:3000\(URLHost.signUp)"
     let body = SignUpUserRequestDto(userEmail: email, userName: name)
 
     return alamofireSession

--- a/Mongsil/Mongsil/Module/Component/Services/SignUpService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/SignUpService.swift
@@ -1,0 +1,105 @@
+//
+//  SignUpService.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+import Alamofire
+import Combine
+import CombineExt
+
+public class SignUpService {
+  public typealias ErrorFactory = SignUpServiceErrorFactory
+
+  public let alamofireSession: Session
+
+  public init(alamofireSession: Session) {
+    self.alamofireSession = alamofireSession
+  }
+
+  public func singUp(name: String, with email: String) -> AnyPublisher<SignUpUserResponseDto, Error> {
+    let url = "3.34.46.139:3000\(URLHost.signUp)"
+    let body = SignUpUserRequestDto(userEmail: email, userName: name)
+
+    return alamofireSession
+      .request(
+        url,
+        method: .post,
+        parameters: body,
+        encoder: JSONParameterEncoder.default
+      )
+      .validate(statusCode: 200..<300)
+      .publishData()
+      .tryMap({ dataResponse -> CommonResponseDto.ExistData<SignUpUserResponseDto> in
+        switch dataResponse.result {
+        case let .success(data):
+          do {
+            return try JSONDecoder().decode(CommonResponseDto.ExistData<SignUpUserResponseDto>.self, from: data)
+          } catch {
+            throw ErrorFactory.decodeFailed(
+              url: url,
+              data: data,
+              underlying: error
+            )
+          }
+        case let .failure(error):
+          throw ErrorFactory.signUpFailed(url: url, underlying: error)
+        }
+      })
+      .tryMap({ response -> CommonResponseDto.ExistData<SignUpUserResponseDto> in
+        if response.statusCode == "200" {
+          return response
+        } else {
+          throw ErrorFactory.signUpFailed(
+            url: url,
+            statusCode: response.statusCode,
+            underlying: nil
+          )
+        }
+      })
+      .compactMap { $0.data }
+      .eraseToAnyPublisher()
+  }
+}
+
+public enum SignUpServiceErrorFactory: ErrorFactory {
+  public enum Code: Int {
+    case decodeFailed = 1
+    case signUpFailed = 2
+  }
+
+  public static func decodeFailed(
+    url: String,
+    data: Data,
+    underlying: Error
+  ) -> NSError {
+    return NSError(
+      domain: domain,
+      code: Code.decodeFailed.rawValue,
+      userInfo: [
+        "identifier": String(reflecting: Code.decodeFailed),
+        "url": url,
+        "data": data,
+        NSUnderlyingErrorKey: underlying
+      ]
+    )
+  }
+
+  public static func signUpFailed(
+    url: String,
+    statusCode: String? = nil,
+    underlying: Error? = nil
+  ) -> NSError {
+    return NSError(
+      domain: domain,
+      code: Code.signUpFailed.rawValue,
+      userInfo: [
+        "identifier": String(reflecting: Code.signUpFailed),
+        "url": url,
+        "statusCode": statusCode as Any,
+        NSUnderlyingErrorKey: underlying as Any
+      ]
+    )
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/URL/URLHost.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/URL/URLHost.swift
@@ -1,0 +1,23 @@
+//
+//  URLHost.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/06.
+//
+
+public enum URLHost: CustomStringConvertible {
+  case checkUser
+  case signUp
+  case dropout
+
+  public var description: String {
+    switch self {
+    case .checkUser:
+      return "/user/checkUser"
+    case .signUp:
+      return "/user/save"
+    case .dropout:
+      return "/user/expire"
+    }
+  }
+}

--- a/Mongsil/Mongsil/Module/Component/Services/UserService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/UserService.swift
@@ -60,7 +60,7 @@ public class UserService {
   }
 
   public func searchUserID(with email: String) ->  AnyPublisher<CheckUserResponseDto, Error> {
-    let url = "3.34.46.139:3000\(URLHost.checkUser)"
+    let url = "http://3.34.46.139:3000\(URLHost.checkUser)"
     let body = CheckUserRequestDto(userEmail: email)
 
     return alamofireSession

--- a/Mongsil/Mongsil/Module/Component/Services/UserService.swift
+++ b/Mongsil/Mongsil/Module/Component/Services/UserService.swift
@@ -5,16 +5,22 @@
 //  Created by Chanwoo Cho on 2022/05/01.
 //
 
+import Alamofire
 import Combine
 import CombineExt
 
 public class UserService {
+  public typealias ErrorFactory = UserServiceErrorFactory
+
   public var defaults: UserDefaults
+  public let alamofireSession: Session
 
   public init(
-    defaults: UserDefaults
+    defaults: UserDefaults,
+    alamofireSession: Session
   ) {
     self.defaults = defaults
+    self.alamofireSession = alamofireSession
   }
 
   public func isLogined() -> AnyPublisher<Bool, Never> {
@@ -35,7 +41,7 @@ public class UserService {
     isKakao: Bool,
     name: String,
     email: String,
-    userID: String? = nil
+    appleUserID: String? = nil
   ) -> AnyPublisher<Void, Never> {
     return Publishers.Create<Void, Never>(factory: { [unowned self] subscribers -> Cancellable in
       subscribers.send(
@@ -44,7 +50,7 @@ public class UserService {
           isKakao: isKakao,
           name: name,
           email: email,
-          userID: userID
+          appleUserID: appleUserID
         )
       )
       subscribers.send(completion: .finished)
@@ -53,12 +59,56 @@ public class UserService {
     .eraseToAnyPublisher()
   }
 
+  public func searchUserID(with email: String) ->  AnyPublisher<CheckUserResponseDto, Error> {
+    let url = "3.34.46.139:3000\(URLHost.checkUser)"
+    let body = CheckUserRequestDto(userEmail: email)
+
+    return alamofireSession
+      .request(
+        url,
+        method: .post,
+        parameters: body,
+        encoder: JSONParameterEncoder.default
+      )
+      .validate(statusCode: 200..<300)
+      .publishData()
+      .tryMap({ dataResponse -> CommonResponseDto.ExistData<CheckUserResponseDto> in
+        switch dataResponse.result {
+        case let .success(data):
+          do {
+            return try JSONDecoder().decode(CommonResponseDto.ExistData<CheckUserResponseDto>.self, from: data)
+          } catch {
+            throw ErrorFactory.decodeFailed(
+              url: url,
+              data: data,
+              underlying: error
+            )
+          }
+        case let .failure(error):
+          throw ErrorFactory.checkUserFailed(url: url, underlying: error)
+        }
+      })
+      .tryMap({ response -> CommonResponseDto.ExistData<CheckUserResponseDto> in
+        if response.statusCode == "200" {
+          return response
+        } else {
+          throw ErrorFactory.checkUserFailed(
+            url: url,
+            statusCode: response.statusCode,
+            underlying: nil
+          )
+        }
+      })
+      .compactMap { $0.data }
+      .eraseToAnyPublisher()
+  }
+
   private func setUserDefaults(
     isLogined: Bool,
     isKakao: Bool,
     name: String,
     email: String,
-    userID: String? = nil
+    appleUserID: String? = nil
   ) {
     self.defaults.set(isLogined, forKey: "isLogined")
     if isKakao {
@@ -69,7 +119,48 @@ public class UserService {
       self.defaults.set(isKakao, forKey: "isKakao")
       self.defaults.set(name, forKey: "appleName")
       self.defaults.set(email, forKey: "appleEmail")
-      self.defaults.set(userID, forKey: "appleUserID")
+      self.defaults.set(appleUserID, forKey: "appleUserID")
     }
+  }
+}
+
+public enum UserServiceErrorFactory: ErrorFactory {
+  public enum Code: Int {
+    case decodeFailed = 1
+    case checkUserFailed = 2
+  }
+
+  public static func decodeFailed(
+    url: String,
+    data: Data,
+    underlying: Error
+  ) -> NSError {
+    return NSError(
+      domain: domain,
+      code: Code.decodeFailed.rawValue,
+      userInfo: [
+        "identifier": String(reflecting: Code.decodeFailed),
+        "url": url,
+        "data": data,
+        NSUnderlyingErrorKey: underlying
+      ]
+    )
+  }
+
+  public static func checkUserFailed(
+    url: String,
+    statusCode: String? = nil,
+    underlying: Error? = nil
+  ) -> NSError {
+    return NSError(
+      domain: domain,
+      code: Code.checkUserFailed.rawValue,
+      userInfo: [
+        "identifier": String(reflecting: Code.checkUserFailed),
+        "url": url,
+        "statusCode": statusCode as Any,
+        NSUnderlyingErrorKey: underlying as Any
+      ]
+    )
   }
 }

--- a/Mongsil/Mongsil/Module/Feature/MainTab/MainTabCore.swift
+++ b/Mongsil/Mongsil/Module/Feature/MainTab/MainTabCore.swift
@@ -62,15 +62,18 @@ struct MainTabEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
   var kakaoLoginService: KakaoLoginService
   var userService: UserService
+  var signUpService: SignUpService
 
   init(
     mainQueue: AnySchedulerOf<DispatchQueue>,
     kakaoLoginService: KakaoLoginService,
-    userService: UserService
+    userService: UserService,
+    signUpService: SignUpService
   ) {
     self.mainQueue = mainQueue
     self.kakaoLoginService = kakaoLoginService
     self.userService = userService
+    self.signUpService = signUpService
   }
 }
 
@@ -123,7 +126,8 @@ Reducer.combine([
       environment: {
         LoginEnvironment(
           kakaoLoginService: $0.kakaoLoginService,
-          userService: $0.userService
+          userService: $0.userService,
+          signUpService: $0.signUpService
         )
       }
     ) as Reducer<WithSharedState<MainTabState>, MainTabAction, MainTabEnvironment>,

--- a/Mongsil/generated/R.generated.swift
+++ b/Mongsil/generated/R.generated.swift
@@ -51,7 +51,8 @@ struct R: Rswift.Validatable {
     // Note: key might not exist in chosen language (in that case, key will be shown)
     for language in languages {
       if let lproj = hostingBundle.url(forResource: language, withExtension: "lproj"),
-         let lbundle = Bundle(url: lproj) {
+         let lbundle = Bundle(url: lproj)
+      {
         let strings = lbundle.url(forResource: tableName, withExtension: "strings")
         let stringsdict = lbundle.url(forResource: tableName, withExtension: "stringsdict")
 
@@ -504,9 +505,9 @@ struct R: Rswift.Validatable {
     }
 
     static func validate() throws {
-      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
     }
 
     fileprivate init() {}

--- a/Mongsil/generated/R.generated.swift
+++ b/Mongsil/generated/R.generated.swift
@@ -51,8 +51,7 @@ struct R: Rswift.Validatable {
     // Note: key might not exist in chosen language (in that case, key will be shown)
     for language in languages {
       if let lproj = hostingBundle.url(forResource: language, withExtension: "lproj"),
-         let lbundle = Bundle(url: lproj)
-      {
+         let lbundle = Bundle(url: lproj) {
         let strings = lbundle.url(forResource: tableName, withExtension: "strings")
         let stringsdict = lbundle.url(forResource: tableName, withExtension: "stringsdict")
 
@@ -505,9 +504,9 @@ struct R: Rswift.Validatable {
     }
 
     static func validate() throws {
-      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
-      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description:"[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardMedium(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Medium' could not be loaded, is 'Pretendard-Medium.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardRegular(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-Regular' could not be loaded, is 'Pretendard-Regular.ttf' added to the UIAppFonts array in this targets Info.plist?") }
+      if R.font.pretendardSemiBold(size: 42) == nil { throw Rswift.ValidationError(description: "[R.swift] Font 'Pretendard-SemiBold' could not be loaded, is 'Pretendard-SemiBold.ttf' added to the UIAppFonts array in this targets Info.plist?") }
     }
 
     fileprivate init() {}


### PR DESCRIPTION
### Task
- 회원조회/가입/탈퇴 API 연동

### Description
- 현재 API 명세가된 회원조회/가입/탈퇴에 대한 API 연동 구현
- Data 존재 여부에 따라 RequestDto를 공통적으로 설계 및 구현
- 각 API별 ResponseDto를 설계 및 구현

### Notes
- 현재 서버 DB 커넥션 이슈와 수정 작업중에 있어 클라에서 별도 수정할건 없지만 서버가 다운된 상태라 테스트는 되지 않을 수 있습니다.
- Login쪽에서 조회/가입 API Service는 호출 구현했으며 추후 필요한 부분이 있을 시 추가 연동 구현하면 됩니다.
- 회원탈퇴는 Service 구현은 되었지만 아직 설정/계정쪽 화면 작업에 들어가지 않아 별도로 Core에서 사용하진 않고 있습니다.