### PR TITLE
refactor: home storage initial view

### DIFF
--- a/Mongsil/Mongsil.xcodeproj/project.pbxproj
+++ b/Mongsil/Mongsil.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		122236F028024DF1009D5C66 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122236EF28024DF1009D5C66 /* R.generated.swift */; };
 		12273EF027F91076007624C1 /* AppTrackingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12273EEF27F91076007624C1 /* AppTrackingService.swift */; };
 		1229909428026001009BF616 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1229909328026001009BF616 /* Assets.xcassets */; };
+		122E1074282B9B7E0034DF37 /* DiaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122E1073282B9B7E0034DF37 /* DiaryView.swift */; };
+		122E1076282B9B830034DF37 /* DiaryCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122E1075282B9B830034DF37 /* DiaryCore.swift */; };
+		122E1079282BA2B20034DF37 /* DreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122E1078282BA2B20034DF37 /* DreamView.swift */; };
+		122E107C282BA2C40034DF37 /* DreamCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122E107B282BA2C40034DF37 /* DreamCore.swift */; };
 		123DD564280283410020440E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123DD563280283410020440E /* Theme.swift */; };
 		123DD5662802889D0020440E /* Image+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123DD5652802889D0020440E /* Image+Generated.swift */; };
 		123DD56928028A130020440E /* UIImage+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123DD56828028A130020440E /* UIImage+extensions.swift */; };
@@ -123,6 +127,10 @@
 		122236EF28024DF1009D5C66 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = R.generated.swift; path = generated/R.generated.swift; sourceTree = SOURCE_ROOT; };
 		12273EEF27F91076007624C1 /* AppTrackingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTrackingService.swift; sourceTree = "<group>"; };
 		1229909328026001009BF616 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		122E1073282B9B7E0034DF37 /* DiaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryView.swift; sourceTree = "<group>"; };
+		122E1075282B9B830034DF37 /* DiaryCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCore.swift; sourceTree = "<group>"; };
+		122E1078282BA2B20034DF37 /* DreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamView.swift; sourceTree = "<group>"; };
+		122E107B282BA2C40034DF37 /* DreamCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamCore.swift; sourceTree = "<group>"; };
 		123DD563280283410020440E /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		123DD5652802889D0020440E /* Image+Generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Generated.swift"; sourceTree = "<group>"; };
 		123DD56828028A130020440E /* UIImage+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+extensions.swift"; sourceTree = "<group>"; };
@@ -287,6 +295,24 @@
 				120BBCAB2802565900AD44B5 /* Pretendard */,
 			);
 			path = Fonts;
+			sourceTree = "<group>";
+		};
+		122E1077282B9B860034DF37 /* Diary */ = {
+			isa = PBXGroup;
+			children = (
+				122E1073282B9B7E0034DF37 /* DiaryView.swift */,
+				122E1075282B9B830034DF37 /* DiaryCore.swift */,
+			);
+			path = Diary;
+			sourceTree = "<group>";
+		};
+		122E107A282BA2B60034DF37 /* Dream */ = {
+			isa = PBXGroup;
+			children = (
+				122E1078282BA2B20034DF37 /* DreamView.swift */,
+				122E107B282BA2C40034DF37 /* DreamCore.swift */,
+			);
+			path = Dream;
 			sourceTree = "<group>";
 		};
 		123DD567280288A10020440E /* Images */ = {
@@ -609,6 +635,7 @@
 				1214C0E6280E7A45002D2C4C /* Login */,
 				773AE2A22807235D006861FC /* Record */,
 				773AE2A328072360006861FC /* Storage */,
+				122E107A282BA2B60034DF37 /* Dream */,
 				123EE08B280453B500D34B93 /* Setting */,
 			);
 			path = Feature;
@@ -677,6 +704,7 @@
 			children = (
 				773AE2AD28072419006861FC /* StorageView.swift */,
 				773AE2AF28072421006861FC /* StorageCore.swift */,
+				122E1077282B9B860034DF37 /* Diary */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -887,15 +915,18 @@
 				123EE09928045F0C00D34B93 /* TermsView.swift in Sources */,
 				123DD56928028A130020440E /* UIImage+extensions.swift in Sources */,
 				125F84B0280D124700279C42 /* AlertSingleButtonView.swift in Sources */,
+				122E1074282B9B7E0034DF37 /* DiaryView.swift in Sources */,
 				12E6EE352828CEFF00504CE3 /* SearchView.swift in Sources */,
 				7779D71A281ADE2F00683C1F /* Dream.swift in Sources */,
 				123EE08A280453B300D34B93 /* SettingCore.swift in Sources */,
 				123EE09728045B3600D34B93 /* ListButtonItemWithText.swift in Sources */,
 				12083C97281636700020E20E /* Toast.swift in Sources */,
 				773AE2AA280723F7006861FC /* RecordView.swift in Sources */,
+				122E107C282BA2C40034DF37 /* DreamCore.swift in Sources */,
 				1291296527F812D80017E087 /* Effect+extensions.swift in Sources */,
 				773AE2A8280723E6006861FC /* MainTabCore.swift in Sources */,
 				125F84B2280D124F00279C42 /* AlertDoubleButtonCore.swift in Sources */,
+				122E1079282BA2B20034DF37 /* DreamView.swift in Sources */,
 				7779D71C281ADE3600683C1F /* User.swift in Sources */,
 				123EE088280453AB00D34B93 /* SettingView.swift in Sources */,
 				125F84AC280D122500279C42 /* AlertSingleButtonCore.swift in Sources */,
@@ -913,6 +944,7 @@
 				123DD5662802889D0020440E /* Image+Generated.swift in Sources */,
 				1292B189282495030050A10D /* SignUpService.swift in Sources */,
 				123EE0A028045F5700D34B93 /* PersonalInfoPolicyCore.swift in Sources */,
+				122E1076282B9B830034DF37 /* DiaryCore.swift in Sources */,
 				123EE08F280453D900D34B93 /* ProfileCore.swift in Sources */,
 				123EE077280452C900D34B93 /* ListItemWithText.swift in Sources */,
 				123EE07A280452E600D34B93 /* Separator.swift in Sources */,

--- a/Mongsil/Mongsil/Module/Component/Views/TabView/MSTabView.swift
+++ b/Mongsil/Mongsil/Module/Component/Views/TabView/MSTabView.swift
@@ -28,37 +28,40 @@ public struct MSTabView<Selection>: View where Selection: Hashable & Identifiabl
 
   public var body: some View {
     GeometryReader { geometry in
-      VStack(spacing: 0) {
-        views[selection]
-
-        Spacer(minLength: 0)
-
-        HStack(spacing: 0) {
-          ForEach(
-            views.keys.sorted(),
-            content: { key in
-              if let activeIcon = activeIcons[key],
-                 let disabledIcon = disabledIcons[key] {
-                MSTab(
-                  activeIcon: activeIcon,
-                  disabledIcon: disabledIcon,
-                  selected: selection == key,
-                  action: { selection = key }
-                )
+      ZStack {
+        VStack(spacing: 0) {
+          views[selection]
+          Spacer(minLength: 0)
+        }
+        VStack {
+          Spacer()
+          HStack(spacing: 0) {
+            ForEach(
+              views.keys.sorted(),
+              content: { key in
+                if let activeIcon = activeIcons[key],
+                   let disabledIcon = disabledIcons[key] {
+                  MSTab(
+                    activeIcon: activeIcon,
+                    disabledIcon: disabledIcon,
+                    selected: selection == key,
+                    action: { selection = key }
+                  )
+                }
               }
-            }
+            )
+          }
+          .cornerRadius(20)
+          .overlay(
+            RoundedRectangle(20)
+              .stroke(Color.gray8, lineWidth: 1)
+              .frame(
+                width: geometry.width + 1,
+                height: geometry.height + 1
+              ),
+            alignment: .top
           )
         }
-        .cornerRadius(20)
-        .overlay(
-          RoundedRectangle(20)
-            .stroke(Color.gray8, lineWidth: 1)
-            .frame(
-              width: geometry.width + 1,
-              height: geometry.height + 1
-            ),
-          alignment: .top
-        )
       }
       .ignoresSafeArea(.container, edges: .bottom)
     }

--- a/Mongsil/Mongsil/Module/Feature/Dream/DreamCore.swift
+++ b/Mongsil/Mongsil/Module/Feature/Dream/DreamCore.swift
@@ -1,0 +1,32 @@
+//
+//  DreamCore.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/11.
+//
+
+import Combine
+import ComposableArchitecture
+
+struct DreamState: Equatable {
+  var dream: DreamInfo
+
+  init(dream: DreamInfo) {
+    self.dream = dream
+  }
+}
+
+enum DreamAction {
+  case backButtonTapped
+}
+
+struct DreamEnvironment {
+}
+
+let dreamReducer = Reducer<WithSharedState<DreamState>, DreamAction, DreamEnvironment> {
+  _, action, _ in
+  switch action {
+  case .backButtonTapped:
+    return .none
+  }
+}

--- a/Mongsil/Mongsil/Module/Feature/Dream/DreamView.swift
+++ b/Mongsil/Mongsil/Module/Feature/Dream/DreamView.swift
@@ -1,0 +1,32 @@
+//
+//  DreamView.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/11.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct DreamView: View {
+  private let store: Store<WithSharedState<DreamState>, DreamAction>
+
+  init(store: Store<WithSharedState<DreamState>, DreamAction>) {
+    self.store = store
+  }
+
+  var body: some View {
+    VStack {
+      MSNavigationBar(
+        backButtonAction: { ViewStore(store).send(.backButtonTapped) }
+      )
+
+      WithViewStore(store.scope(state: \.local.dream)) { dreamViewStore in
+        Text("\(dreamViewStore.state.title)")
+      }
+
+      Spacer()
+    }
+    .navigationBarHidden(true)
+  }
+}

--- a/Mongsil/Mongsil/Module/Feature/Storage/Diary/DiaryCore.swift
+++ b/Mongsil/Mongsil/Module/Feature/Storage/Diary/DiaryCore.swift
@@ -1,0 +1,32 @@
+//
+//  DiaryCore.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/11.
+//
+
+import Combine
+import ComposableArchitecture
+
+struct DiaryState: Equatable {
+  var diary: Diary
+
+  init(diary: Diary) {
+    self.diary = diary
+  }
+}
+
+enum DiaryAction {
+  case backButtonTapped
+}
+
+struct DiaryEnvironment {
+}
+
+let diaryReducer = Reducer<WithSharedState<DiaryState>, DiaryAction, DiaryEnvironment> {
+  _, action, _ in
+  switch action {
+  case .backButtonTapped:
+    return .none
+  }
+}

--- a/Mongsil/Mongsil/Module/Feature/Storage/Diary/DiaryView.swift
+++ b/Mongsil/Mongsil/Module/Feature/Storage/Diary/DiaryView.swift
@@ -1,0 +1,32 @@
+//
+//  DiaryView.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/05/11.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct DiaryView: View {
+  private let store: Store<WithSharedState<DiaryState>, DiaryAction>
+
+  init(store: Store<WithSharedState<DiaryState>, DiaryAction>) {
+    self.store = store
+  }
+
+  var body: some View {
+    VStack {
+      MSNavigationBar(
+        backButtonAction: { ViewStore(store).send(.backButtonTapped) }
+      )
+
+      WithViewStore(store.scope(state: \.local.diary)) { diaryViewStore in
+        Text("\(diaryViewStore.state.title)")
+      }
+
+      Spacer()
+    }
+    .navigationBarHidden(true)
+  }
+}

--- a/Mongsil/Mongsil/Module/Feature/Storage/StorageView.swift
+++ b/Mongsil/Mongsil/Module/Feature/Storage/StorageView.swift
@@ -165,6 +165,20 @@ private struct DiaryListView: View {
             }
           }
         }
+        .overlay(
+          VStack {
+            Spacer()
+            Rectangle()
+              .foregroundColor(.gray11)
+              .opacity(0.8)
+              .frame(maxWidth: .infinity, maxHeight: 90)
+              .background {
+                Color.gray11
+                  .opacity(0.8)
+                  .blur(radius: 0)
+              }
+          }
+        )
         .frame(maxWidth: .infinity)
       } else {
         EmptyDiaryOrDreamView(description: "아직 기록된 꿈일기가 없어요.")
@@ -266,6 +280,20 @@ private struct DreamListView: View {
             }
             .padding(.horizontal, 20)
           }
+          .overlay(
+            VStack {
+              Spacer()
+              Rectangle()
+                .foregroundColor(.gray11)
+                .opacity(0.8)
+                .frame(maxWidth: .infinity, maxHeight: 90)
+                .background {
+                  Color.gray11
+                    .opacity(0.8)
+                    .blur(radius: 0)
+                }
+            }
+          )
           .frame(maxWidth: .infinity)
         } else {
           EmptyDiaryOrDreamView(description: "아직 저장된 해몽이 없어요.")


### PR DESCRIPTION
### Task
- 탭바 오버레이를 통해 블러와 비슷한 노출이 되도록 리팩토링 하였습니다.
- 보관함에서 꿈일기/해몽 카드에 대해 선택 시 다음 뷰로 정보 전달 및 노출될 수 있도록 네비게이션 링크를 주었습니다.

### Description
- 꿈일기/해몽카드를 선택했을때 나오는 결과 화면의 디자인이 아직 없어 정보만 전달해둔 상태로 디자인이 곧 나온다면 바로 이어서 해당 Task를 진행할 예정입니다.
- 보관함 부분을 리팩토링하면서 아직 네비게이션바 부분과 월(month) 셀렉 바텀시트 구현은 하지 않았습니다.
네비게이션바는 승후님과 컨플릭이 많이 날 거라 예상해 작업하고 계신 컴포넌트를 사용하려합니다.
월 셀렉 바텀시트 구현은 내일 쳐낼 예정입니다.