### PR TITLE
fix: maintextfield avoid when keybord pop up

### DIFF
--- a/Mongsil/Mongsil/Module/Component/Extensions/View/View+extensions.swift
+++ b/Mongsil/Mongsil/Module/Component/Extensions/View/View+extensions.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 extension View {
   public func `if`<Content: View>(
@@ -18,15 +19,15 @@ extension View {
       return self.eraseToAnyView()
     }
   }
-
+  
   public func apply<Content: View>(content: (Self) -> Content) -> AnyView {
     return content(self).eraseToAnyView()
   }
-
+  
   public func eraseToAnyView() -> AnyView {
     return AnyView(self)
   }
-
+  
   public func shadow(
     color: Color,
     x: CGFloat,
@@ -44,30 +45,30 @@ extension View {
       y: spreadedY
     )
   }
-
+  
   public func cornerRadius(
     _ radius: CGFloat,
     corners: UIRectCorner
   ) -> some View {
     clipShape(RoundedCorner(radius: radius, corners: corners))
   }
-
+  
   public func placeholder<Content: View>(
     when shouldShow: Bool,
     alignment: Alignment = .leading,
     @ViewBuilder placeholder: () -> Content) -> some View {
-
+      
       ZStack(alignment: alignment) {
         placeholder().opacity(shouldShow ? 1 : 0)
         self
       }
     }
-
+  
   public func hideKeyboard() {
     let resign = #selector(UIResponder.resignFirstResponder)
     UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
   }
-
+  
   public func onKeyboard(_ keyboardYOffset: Binding<CGFloat>) -> some View {
     return ModifiedContent(content: self, modifier: KeyboardModifier(keyboardYOffset))
   }
@@ -76,7 +77,7 @@ extension View {
 public struct RoundedCorner: Shape {
   public var radius: CGFloat = .infinity
   public var corners: UIRectCorner = .allCorners
-
+  
   public func path(in rect: CGRect) -> Path {
     let path = UIBezierPath(
       roundedRect: rect,
@@ -91,11 +92,11 @@ public struct KeyboardModifier: ViewModifier {
   @Binding var keyboardYOffset: CGFloat
   let keyboardWillAppearPublisher = NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
   let keyboardWillHidePublisher = NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
-
+  
   init(_ offset: Binding<CGFloat>) {
     _keyboardYOffset = offset
   }
-
+  
   public func body(content: Content) -> some View {
     let anumationValue = 0
     return content.offset(x: 0, y: -$keyboardYOffset.wrappedValue)
@@ -114,5 +115,41 @@ public struct KeyboardModifier: ViewModifier {
       }.onReceive(keyboardWillHidePublisher) { _ in
         self.$keyboardYOffset.wrappedValue = 0
       }
+  }
+}
+
+struct AdaptsToKeyboard: ViewModifier {
+  @State var currentHeight: CGFloat = 0
+  
+  func body(content: Content) -> some View {
+    GeometryReader { geometry in
+      content
+        .padding(.bottom, self.currentHeight)
+        .onAppear(perform: {
+          NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillShowNotification)
+            .merge(with: NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillChangeFrameNotification))
+            .compactMap { notification in
+              withAnimation(.easeOut(duration: 0.16)) {
+                notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+              }
+            }
+            .map { rect in
+              rect.height - geometry.safeAreaInsets.bottom
+            }
+            .subscribe(Subscribers.Assign(object: self, keyPath: \.currentHeight))
+          
+          NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillHideNotification)
+            .compactMap { notification in
+              CGFloat.zero
+            }
+            .subscribe(Subscribers.Assign(object: self, keyPath: \.currentHeight))
+        })
+    }
+  }
+}
+
+extension View {
+  func adaptsToKeyboard() -> some View {
+    return modifier(AdaptsToKeyboard())
   }
 }

--- a/Mongsil/Mongsil/Module/Feature/Record/RecordView.swift
+++ b/Mongsil/Mongsil/Module/Feature/Record/RecordView.swift
@@ -155,6 +155,7 @@ private struct MainTextView: View {
           hideKeyboard()
         }
       }
+      .adaptsToKeyboard()
     }
   }
 }


### PR DESCRIPTION
maintextfiled가 keybord가 보였을때도 가려지지 않게 수정해주었습니다!

![Simulator Screen Recording - iPhone 11 - 2022-05-18 at 10 44 33](https://user-images.githubusercontent.com/77050826/168943335-dd06cdf6-5824-4ec4-baea-024d748b1e82.gif)
