### PR TITLE
feat: Searchbar and Diary card alert modal

### DIFF
--- a/Mongsil/Mongsil.xcodeproj/project.pbxproj
+++ b/Mongsil/Mongsil.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		126E471028220181008D1554 /* AppleLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126E470F28220181008D1554 /* AppleLoginService.swift */; };
 		126EF42D27F2AC2400102FA9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 126EF42C27F2AC2400102FA9 /* Assets.xcassets */; };
 		126EF43027F2AC2400102FA9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 126EF42F27F2AC2400102FA9 /* Preview Assets.xcassets */; };
+		1276A238284DA5B2007C4485 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276A237284DA5B2007C4485 /* SearchBar.swift */; };
 		127EBD78280A65960011C556 /* UINavigationController+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127EBD77280A65960011C556 /* UINavigationController+extensions.swift */; };
 		1287FDC128288A23004B55A9 /* Pretendard-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1287FDC028288A23004B55A9 /* Pretendard-Light.ttf */; };
 		1291296527F812D80017E087 /* Effect+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1291296427F812D80017E087 /* Effect+extensions.swift */; };
@@ -199,6 +200,7 @@
 		126EF42527F2AC2400102FA9 /* Mongsil.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mongsil.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		126EF42C27F2AC2400102FA9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		126EF42F27F2AC2400102FA9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		1276A237284DA5B2007C4485 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		127EBD77280A65960011C556 /* UINavigationController+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+extensions.swift"; sourceTree = "<group>"; };
 		1287FDC028288A23004B55A9 /* Pretendard-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.ttf"; sourceTree = "<group>"; };
 		1291296427F812D80017E087 /* Effect+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Effect+extensions.swift"; sourceTree = "<group>"; };
@@ -594,6 +596,14 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		1276A239284DA5B5007C4485 /* SearchBar */ = {
+			isa = PBXGroup;
+			children = (
+				1276A237284DA5B2007C4485 /* SearchBar.swift */,
+			);
+			path = SearchBar;
+			sourceTree = "<group>";
+		};
 		1291296327F8129C0017E087 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -634,6 +644,7 @@
 				12590E89282C8DDA000FB712 /* BottomSheet */,
 				12A56FD72838938100CDEF6E /* CardResultView */,
 				120BF4392839435C00FB8677 /* ActivityView */,
+				1276A239284DA5B5007C4485 /* SearchBar */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1062,6 +1073,7 @@
 				12D7D3CD281E91EA00B83DDE /* UserService.swift in Sources */,
 				12590E8B282C8DEF000FB712 /* BottomSheet.swift in Sources */,
 				12952A61280250A300C89DD7 /* Font+extensions.swift in Sources */,
+				1276A238284DA5B2007C4485 /* SearchBar.swift in Sources */,
 				1214C0E3280E7A37002D2C4C /* LoginView.swift in Sources */,
 				12A56FDB2838955800CDEF6E /* CardResult.swift in Sources */,
 				124DBC7E282A1213005C3ED4 /* Diary.swift in Sources */,

--- a/Mongsil/Mongsil/Module/Component/Models/Diary.swift
+++ b/Mongsil/Mongsil/Module/Component/Models/Diary.swift
@@ -12,21 +12,24 @@ public struct Diary: Codable, Equatable, Hashable {
   public let description: String
   public let date: String
   public var images: [String]
+  public var keywords: [String]
 
   public enum CodingKeys: String, CodingKey {
-    case title, description, date, images
+    case title, description, date, images, keywords
   }
 
   public init(
     title: String,
     description: String,
     date: String,
-    images: [String]
+    images: [String],
+    keywords: [String]
   ) {
     self.title = title
     self.description = description
     self.date = date
     self.images = images
+    self.keywords = keywords
   }
 
   public init(from decoder: Decoder) throws {
@@ -36,6 +39,7 @@ public struct Diary: Codable, Equatable, Hashable {
     self.description = try container.decode(String.self, forKey: .description)
     self.date = try container.decode(String.self, forKey: .date)
     self.images = try container.decode([String].self, forKey: .images)
+    self.keywords = try container.decode([String].self, forKey: .keywords)
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -44,6 +48,7 @@ public struct Diary: Codable, Equatable, Hashable {
     try container.encode(description, forKey: .description)
     try container.encode(date, forKey: .date)
     try container.encode(images, forKey: .images)
+    try container.encode(keywords, forKey: .keywords)
   }
 }
 
@@ -65,7 +70,8 @@ extension Diary {
       images: [
         "https://user-images.githubusercontent.com/72292617/169724165-75c12342-83fb-4673-a2d9-460f9a14104d.png",
         "https://user-images.githubusercontent.com/72292617/169724245-232f119e-6312-41f3-9f63-98b4957a4ec4.png"
-      ]
+      ],
+      keywords: ["호랑이", "달아나다"]
     )
     public static let diary2 = Diary(
       title: "돼지가 돈다발을 들고 오는 꿈",
@@ -74,7 +80,8 @@ extension Diary {
       images: [
         "https://user-images.githubusercontent.com/72292617/169724165-75c12342-83fb-4673-a2d9-460f9a14104d.png",
         "https://user-images.githubusercontent.com/72292617/169724245-232f119e-6312-41f3-9f63-98b4957a4ec4.png"
-      ]
+      ],
+      keywords: ["돼지", "돈다발"]
     )
     public static let diary3 = Diary(
       title: "귀신에게 쫓기는 꿈",
@@ -83,7 +90,8 @@ extension Diary {
       images: [
         "https://user-images.githubusercontent.com/72292617/169724165-75c12342-83fb-4673-a2d9-460f9a14104d.png",
         "https://user-images.githubusercontent.com/72292617/169724245-232f119e-6312-41f3-9f63-98b4957a4ec4.png"
-      ]
+      ],
+      keywords: ["귀신", "쫓기다"]
     )
     public static let diary4 = Diary(
       title: "다리가 잘리는 꿈",
@@ -92,7 +100,8 @@ extension Diary {
       images: [
         "https://user-images.githubusercontent.com/72292617/169724165-75c12342-83fb-4673-a2d9-460f9a14104d.png",
         "https://user-images.githubusercontent.com/72292617/169724245-232f119e-6312-41f3-9f63-98b4957a4ec4.png"
-      ]
+      ],
+      keywords: ["다리"]
     )
     public static let diary5 = Diary(
       title: "로또에 당첨되는 꿈",
@@ -100,7 +109,8 @@ extension Diary {
       date: convertDateToString(Date()),
       images: [
         "https://user-images.githubusercontent.com/72292617/169724165-75c12342-83fb-4673-a2d9-460f9a14104d.png"
-      ]
+      ],
+      keywords: ["로또"]
     )
     public static let diary6 = Diary(
       title: "절벽에서 뛰어내리는 꿈",
@@ -108,7 +118,8 @@ extension Diary {
       date: "2022.04.10",
       images: [
         "https://user-images.githubusercontent.com/72292617/169724165-75c12342-83fb-4673-a2d9-460f9a14104d.png"
-      ]
+      ],
+      keywords: ["절벽"]
     )
   }
 }

--- a/Mongsil/Mongsil/Module/Component/Views/AlertModal/AlertDoubleButton/AlertDoubleButtonCore.swift
+++ b/Mongsil/Mongsil/Module/Component/Views/AlertModal/AlertDoubleButton/AlertDoubleButtonCore.swift
@@ -13,6 +13,7 @@ public struct AlertDoubleButtonState: Equatable {
   public var title: String?
   public var body: String
   public var secondaryButtonTitle: String
+  public var secondaryButtonHierachy: AlertButton.Hierarchy = .secondary
   public var primaryButtonTitle: String
   public var primaryButtonHierachy: AlertButton.Hierarchy = .primary
 
@@ -20,12 +21,14 @@ public struct AlertDoubleButtonState: Equatable {
     title: String? = nil,
     body: String,
     secondaryButtonTitle: String = "취소",
+    secondaryButtonHierachy: AlertButton.Hierarchy = .secondary,
     primaryButtonTitle: String = "확인",
     primaryButtonHierachy: AlertButton.Hierarchy = .primary
   ) {
     self.title = title
     self.body = body
     self.secondaryButtonTitle = secondaryButtonTitle
+    self.secondaryButtonHierachy = secondaryButtonHierachy
     self.primaryButtonTitle = primaryButtonTitle
     self.primaryButtonHierachy = primaryButtonHierachy
   }

--- a/Mongsil/Mongsil/Module/Component/Views/AlertModal/AlertDoubleButton/AlertDoubleButtonView.swift
+++ b/Mongsil/Mongsil/Module/Component/Views/AlertModal/AlertDoubleButton/AlertDoubleButtonView.swift
@@ -125,11 +125,13 @@ private struct SecondaryButtonView: View {
 
   var body: some View {
     WithViewStore(store.scope(state: \.secondaryButtonTitle)) { secondaryButtonTitleViewStore in
-      AlertButton(
-        title: secondaryButtonTitleViewStore.state,
-        hierarchy: .secondary
-      ) {
-        ViewStore(store).send(.secondaryButtonTapped)
+      WithViewStore(store.scope(state: \.secondaryButtonHierachy)) { secondaryButtonHierachyViewStore in
+        AlertButton(
+          title: secondaryButtonTitleViewStore.state,
+          hierarchy: secondaryButtonHierachyViewStore.state
+        ) {
+          ViewStore(store).send(.secondaryButtonTapped)
+        }
       }
     }
   }

--- a/Mongsil/Mongsil/Module/Component/Views/SearchBar/SearchBar.swift
+++ b/Mongsil/Mongsil/Module/Component/Views/SearchBar/SearchBar.swift
@@ -1,0 +1,80 @@
+//
+//  SearchBar.swift
+//  Mongsil
+//
+//  Created by Chanwoo Cho on 2022/06/06.
+//
+
+import SwiftUI
+
+public struct SearchBar: View {
+  @Binding public var text: String
+  @Binding public var isSearched: Bool
+  @Binding public var isTextInputed: Bool
+  public var backbuttonAction: () -> Void = {}
+  public var removeButtonAction: () -> Void = {}
+  public var searchButtonAction: () -> Void = {}
+
+  public init(
+    text: Binding<String> = .constant(""),
+    isSearched: Binding<Bool> = .constant(false),
+    isTextInputed: Binding<Bool> = .constant(false),
+    backbuttonAction: @escaping () -> Void = {},
+    removeButtonAction: @escaping () -> Void = {},
+    searchButtonAction: @escaping () -> Void = {}
+  ) {
+    self._text = text
+    self._isSearched = isSearched
+    self._isTextInputed = isTextInputed
+    self.backbuttonAction = backbuttonAction
+    self.removeButtonAction = removeButtonAction
+    self.searchButtonAction = searchButtonAction
+  }
+
+  public var body: some View {
+    HStack(alignment: .center, spacing: 0) {
+      Button(action: backbuttonAction) {
+        R.CustomImage.backIcon.image
+      }
+      Spacer()
+        .frame(width: 10)
+      HStack(alignment: .center, spacing: 0) {
+        Spacer()
+          .frame(width: 8)
+        TextField("", text: $text)
+          .foregroundColor(.gray2)
+          .placeholder(
+            when: text.isEmpty,
+            placeholder: {
+              Text("궁금한 꿈의 키워드를 검색하세요")
+                .foregroundColor(.gray6)
+            }
+          )
+          .font(.caption1)
+          .frame(maxWidth: .infinity)
+        if isTextInputed {
+          Button(action: removeButtonAction) {
+            R.CustomImage.cancelSmallIcon.image
+          }
+        }
+        if !isSearched {
+          Spacer()
+            .frame(width: 8)
+          Button(action: searchButtonAction) {
+            R.CustomImage.searchIcon.image
+          }
+        }
+        Spacer()
+          .frame(width: 8)
+      }
+      .frame(height: 36)
+      .background(Color.gray9)
+      .clipShape(
+        RoundedRectangle(
+          cornerRadius: 8,
+          style: .continuous
+        )
+      )
+    }
+  }
+}

--- a/Mongsil/Mongsil/Module/Feature/Home/HomeView.swift
+++ b/Mongsil/Mongsil/Module/Feature/Home/HomeView.swift
@@ -57,6 +57,8 @@ private struct SeachBarView: View {
         .padding(.leading, 16)
       Spacer()
       R.CustomImage.searchIcon.image
+        .renderingMode(.template)
+        .foregroundColor(.gray6)
         .padding(.trailing, 16)
     }
     .frame(height: 48)

--- a/Mongsil/Mongsil/Module/Feature/Storage/Diary/DiaryView.swift
+++ b/Mongsil/Mongsil/Module/Feature/Storage/Diary/DiaryView.swift
@@ -27,7 +27,7 @@ struct DiaryView: View {
         recordDate: userDiaryViewStore.state.date,
         imageURLs: userDiaryViewStore.state.images,
         title: userDiaryViewStore.state.title,
-        keywords: ["호랑이", "달아나다"],
+        keywords: userDiaryViewStore.state.keywords,
         description: userDiaryViewStore.state.description,
         cardResult: .diary,
         backButtonAction: { ViewStore(store).send(.backButtonTapped) }
@@ -37,6 +37,12 @@ struct DiaryView: View {
       store: store.scope(
         state: \.local.requestDeleteDiaryAlertModal,
         action: DiaryAction.requestDeleteDiaryAlertModal
+      )
+    )
+    .alertDoubleButton(
+      store: store.scope(
+        state: \.local.moveDreamAlertModal,
+        action: DiaryAction.moveDreamAlertModal
       )
     )
   }


### PR DESCRIPTION
### Task
- 다이어리 카드에서 해몽 보러가기 클릭 시 키워드 선택을 위한 얼럿 구현
- Diary 모델 타입에 키워드 추가
- 공통 투버튼 얼럿 hiearachy 추가 및 리팩토링
- 서치바 컴포넌트 구현

### Description
- 현재 서버에서 UserDiary에 대한 DTO를 전달받지 못해 클라에서 해당 명세를 작성해 서버에 요청한 상태입니다.
- 주로 서치바를 컴포넌트를 구현하면서 해당 서치바는 검색하기/기록하기 부분에서 사용될 예정입니다.
- 홈화면에 처음 나타나는 서치바 같은 경우 디자인만 거의 비슷하고 다른 기능으로 별도 컴포넌트 제작없이 해당 홈뷰에서 구현되어 그곳에서만 사용됩니다.
- 추후 서치바가 필요한곳에서 해당 서치바 모듈을 사용하면됩니다.
(만약 수정할 부분들이 필요하거나 한다면 자유롭게 추가 및 수정하시면 됩니다.)
- 아래의 캡쳐 화면은 홈화면에서 단순하게 올려본 서치바의 모습으로 컴포넌트 디자인이 이렇다라는것만 참고해주시면 됩니다.
자세한 액션들을 코드를 참고해주시길 바랍니다. (액션 및 text는 코어에서 바인딩 시켜 사용해야 합니다.)
<img src="https://user-images.githubusercontent.com/72292617/172098943-717f651c-eee2-488e-b8e1-17b2ac4f4d4b.png" width="300" height="600">

