### PR TITLE
feat: Add App Uses Non-Exempt Encryption setting

### DIFF
--- a/Mongsil/Mongsil/Info.plist
+++ b/Mongsil/Mongsil/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
### Task
- 앱 스토어 배포 시 나타날 수 있는 수출 규정 관련 문서 누락 메시지 해결을 위한 코드 추가

### Description
- 몽실 앱은 수출 규정 관련하여 해당되지 않음으로 매번 앱 스토어 배포 시 해당 관련 문서 누락 메시지를 나타나지 않도록 info.plist에서 코드를 통해 설정함 
- 해당 관련하여 수출 규정 관련 문서가 무엇인지 어떻게 설정하는지는 아래 포스팅을 참고하시면 도움이 될것 같습니다.
https://green1229.tistory.com/206